### PR TITLE
Corrected URL and DIR name on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Provide the same trace server api url `trace_url: "jaegertracing:16686"` in `con
 
 ### Build and Deploy
 ```
-git clone https://github.com/s8sg/faas-flow-dashboard
-cd faas-flow-dashboard
+git clone https://github.com/s8sg/faas-flow-tower
+cd faas-flow-tower
 faas build
 faas deploy
 ```


### PR DESCRIPTION
The URL was pointing to `faas-flow-dashboard` instead of `tower`